### PR TITLE
Show connected devices using checkmarks

### DIFF
--- a/ToothTray/ToothTrayMenu.h
+++ b/ToothTray/ToothTrayMenu.h
@@ -29,5 +29,5 @@ private:
     wil::unique_hmenu m_handle;
     std::unordered_map<unsigned int, MenuData> m_menuData;
 
-    MENUITEMINFOW InsertBluetoohConnectorMenuItem(UINT id, UINT position, LPWSTR pText);
+    MENUITEMINFOW InsertBluetoohConnectorMenuItem(UINT id, UINT position, LPWSTR pText, bool checked);
 };


### PR DESCRIPTION
Did my best to implement https://github.com/m2jean/ToothTray/issues/4 

![image](https://user-images.githubusercontent.com/7691630/212396344-9a3108db-dbf2-45c7-bd00-cb6c8f685827.png)

It shows a checkmark for connected devices. It also outputs some debug logging in the style used for printing the enumerated devices elsewhere.

I'm not a C++ person so hopefully I did this right. 🙂 